### PR TITLE
fix: load extensions assets from filesystem drivers

### DIFF
--- a/extend.php
+++ b/extend.php
@@ -16,7 +16,8 @@ use Blomstra\FontAwesome\Content\Frontend;
 use Blomstra\FontAwesome\Providers\FontAwesomeLessImports;
 use Blomstra\FontAwesome\Providers\FontAwesomePreloads;
 use Flarum\Extend;
-use Flarum\Http\UrlGenerator;
+use Illuminate\Contracts\Filesystem\Cloud;
+use Illuminate\Contracts\Filesystem\Factory;
 
 return [
     (new Extend\Frontend('forum'))
@@ -43,10 +44,10 @@ return [
     (new Extend\Theme())
         ->addCustomLessFunction('blomstra-fontawesome-font-urls', function ($style) {
             /**
-             * @var UrlGenerator
+             * @var Cloud
              */
-            $url = resolve(UrlGenerator::class);
-            $uri = $url->to('forum')->base().'/assets/extensions/blomstra-fontawesome/fontawesome-6-free/fa-'.$style;
+            $disk = resolve(Factory::class)->disk('flarum-assets');
+            $uri = $disk->url('extensions/blomstra-fontawesome/fontawesome-6-free/fa-'.$style);
 
             if ($style === 'solid') {
                 $uri .= '-900';

--- a/src/Providers/FontAwesomePreloads.php
+++ b/src/Providers/FontAwesomePreloads.php
@@ -13,27 +13,21 @@
 namespace Blomstra\FontAwesome\Providers;
 
 use Flarum\Foundation\AbstractServiceProvider;
-use Flarum\Http\UrlGenerator;
 use Flarum\Settings\SettingsRepositoryInterface;
+use Illuminate\Contracts\Filesystem\Cloud;
+use Illuminate\Contracts\Filesystem\Factory;
 
 class FontAwesomePreloads extends AbstractServiceProvider
 {
     /**
      * {@inheritdoc}
      */
-    public function boot()
+    public function boot(SettingsRepositoryInterface $settings, Factory $filesystem)
     {
-        /**
-         * @var SettingsRepositoryInterface
-         */
-        $settings = $this->container[SettingsRepositoryInterface::class];
+        /** @var Cloud $disk */
+        $disk = $filesystem->disk('flarum-assets');
 
-        /**
-         * @var UrlGenerator
-         */
-        $url = $this->container[UrlGenerator::class];
-
-        $this->container->extend('flarum.frontend.default_preloads', function (array $preloads) use ($settings, $url) {
+        $this->container->extend('flarum.frontend.default_preloads', function (array $preloads) use ($settings, $disk) {
             // Filter out FontAwesome preloads|
             $preloads = array_filter($preloads, function ($preload) {
                 return ! str_contains($preload['href'], 'fonts/fa-');
@@ -43,19 +37,19 @@ class FontAwesomePreloads extends AbstractServiceProvider
 
             if ($faType === 'free') {
                 $preloads[] = [
-                    'href' => $url->to('forum')->base().'/assets/extensions/blomstra-fontawesome/fontawesome-6-free/fa-brands-400.woff2',
+                    'href' => $disk->url('/extensions/blomstra-fontawesome/fontawesome-6-free/fa-brands-400.woff2'),
                     'as' => 'font',
                     'type' => 'font/woff2',
                     'crossorigin' => ''
                 ];
                 $preloads[] = [
-                    'href' => $url->to('forum')->base().'/assets/extensions/blomstra-fontawesome/fontawesome-6-free/fa-regular-400.woff2',
+                    'href' => $disk->url('/extensions/blomstra-fontawesome/fontawesome-6-free/fa-regular-400.woff2'),
                     'as' => 'font',
                     'type' => 'font/woff2',
                     'crossorigin' => ''
                 ];
                 $preloads[] = [
-                    'href' => $url->to('forum')->base().'/assets/extensions/blomstra-fontawesome/fontawesome-6-free/fa-solid-900.woff2',
+                    'href' => $disk->url('/extensions/blomstra-fontawesome/fontawesome-6-free/fa-solid-900.woff2'),
                     'as' => 'font',
                     'type' => 'font/woff2',
                     'crossorigin' => ''


### PR DESCRIPTION
Uses the URL generated from the filesystem driver instead of locally. This allows the extension to work when using s3/buckets for instance.